### PR TITLE
Changed @eeacms/volto-clms-theme to @eeacms/volto-clms-utils

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,9 @@
     "type": "git",
     "url": "git@github.com:eea/volto-arcgis-block.git"
   },
+  "addons": [
+    "@eeacms/volto-clms-utils"
+  ],
   "scripts": {
     "i18n": "NODE_ENV=production node src/i18n.js",
     "release": "release-it",
@@ -34,7 +37,8 @@
     "esri-loader": "3.1.0",
     "@fortawesome/fontawesome-svg-core": "1.2.35",
     "@fortawesome/free-solid-svg-icons": "5.15.3",
-    "@fortawesome/react-fontawesome": "0.1.14"
+    "@fortawesome/react-fontawesome": "0.1.14",
+    "@eeacms/volto-clms-utils":"git+http://github.com/eea/volto-clms-utils.git#develop"
   },
   "devDependencies": {
     "@cypress/code-coverage": "^3.9.5",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@fortawesome/fontawesome-svg-core": "1.2.35",
     "@fortawesome/free-solid-svg-icons": "5.15.3",
     "@fortawesome/react-fontawesome": "0.1.14",
-    "@eeacms/volto-clms-utils":"git+http://github.com/eea/volto-clms-utils.git#develop"
+    "@eeacms/volto-clms-utils": "0.1.1"
   },
   "devDependencies": {
     "@cypress/code-coverage": "^3.9.5",

--- a/src/components/MapViewer/MenuWidget.jsx
+++ b/src/components/MapViewer/MenuWidget.jsx
@@ -2,7 +2,7 @@ import ReactDOM from 'react-dom';
 import React, { createRef, useState } from 'react';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { loadModules, loadCss } from 'esri-loader';
-import useCartState from '@eeacms/volto-clms-theme/utils/useCartState';
+import useCartState from '@eeacms/volto-clms-utils/cart/useCartState';
 import { useHistory } from 'react-router-dom';
 import { useIntl } from 'react-intl';
 import { Message } from 'semantic-ui-react';


### PR DESCRIPTION
Changed @eeacms/volto-clms-theme/utils/useCartState to @eeacms/volto-clms-utils.

Fixed jenkins bug "Unable to resolve path to module": 
```5:26  warning  Unable to resolve path to module '@eeacms/volto-clms-theme/utils/useCartState'  import/no-unresolved```

To fix this we have abstracted the cart logic interface to a separate dependency. https://github.com/eea/volto-clms-utils/tree/develop