### PR TITLE
CLMS-2422 (bug): Code refactored and cleaned.

### DIFF
--- a/src/components/MapViewer/HotspotWidget.jsx
+++ b/src/components/MapViewer/HotspotWidget.jsx
@@ -599,21 +599,19 @@ class HotspotWidget extends React.Component {
             selectBox.options.add(new Option(option, option, option));
           }
           for (let u = 0; u < selectBox.options.length; u++) {
-            if (selectBox.options[u].label.includes(this.selectedArea)) {
+            if (!selectBox.options[u].label.includes(this.selectedArea)) {
+              selectBox.value = 'default';
+              continue;
+            } else {
               selectBox.value = this.selectedArea;
-              if (this.lcYear === null) selectBoxLcTime.value = 'default';
-              else if (this.lccYear === null)
-                selectBoxLccTime.value = 'default';
-              else {
+              if (this.lcYear !== null) {
                 selectBoxLcTime.value = this.lcYear;
+              }
+              if (this.lccYear !== null) {
                 selectBoxLccTime.value = this.lccYear;
               }
-              break;
-            } else {
-              selectBox.value = 'default';
-              selectBoxLcTime.value = 'default';
-              selectBoxLccTime.value = 'default';
             }
+            break;
           }
           break;
         } else if (
@@ -625,24 +623,23 @@ class HotspotWidget extends React.Component {
             selectBox.options.add(new Option(option, option, option));
           }
           for (let u = 0; u < selectBox.options.length; u++) {
-            if (selectBox.options[u].label.includes(this.selectedArea)) {
+            if (!selectBox.options[u].label.includes(this.selectedArea)) {
+              selectBox.value = 'default';
+              continue;
+            } else {
               selectBox.value = this.selectedArea;
-              if (this.lcYear === null) selectBoxLcTime.value = 'default';
-              else if (this.lccYear === null)
-                selectBoxLccTime.value = 'default';
-              else {
+              if (this.lcYear !== null) {
                 selectBoxLcTime.value = this.lcYear;
+              }
+              if (this.lccYear !== null) {
                 selectBoxLccTime.value = this.lccYear;
               }
-              break;
-            } else {
-              selectBox.value = 'default';
-              selectBoxLcTime.value = 'default';
-              selectBoxLccTime.value = 'default';
             }
+            break;
           }
           break;
         }
+        break;
       }
     }
     if (selectBox.value === 'default') {


### PR DESCRIPTION
As long as selected region exists in new layer options, previously selected region years will remain in focus inside of the year drop down, regardless of changes to widget visibility, menu and active layer page toggling, etc.