### PR TITLE
CLMS-2890 (bug)

### DIFF
--- a/src/components/MapViewer/LegendWidget.jsx
+++ b/src/components/MapViewer/LegendWidget.jsx
@@ -134,6 +134,7 @@ class LegendWidget extends React.Component {
           element.parentNode.appendChild(span);
         } */
         if (
+          typeof img?.closest !== 'undefined' &&
           img?.closest('.esri-legend__service')?.firstElementChild?.nodeName ===
             'H3' &&
           img?.closest('.esri-legend__service')?.firstElementChild


### PR DESCRIPTION
Mapviewer breaks when a user logs in after selecting the snow layer dataset