### PR TITLE
CLMS-DEMO (bug): demo crashes with dynamic land cover datasets becaus…

### DIFF
--- a/src/components/MapViewer/MenuWidget.jsx
+++ b/src/components/MapViewer/MenuWidget.jsx
@@ -3275,7 +3275,7 @@ class MenuWidget extends React.Component {
         img = element;
       }
       // Set Legend opacity back to 1;
-      if (img) {
+      if (img && Object.keys(img).length !== 0) {
         img.setAttribute(
           'style',
           'opacity:1; -moz-opacity:1; filter:alpha(opacity=100)',


### PR DESCRIPTION
…e of attempting to pin legend transparency when no layer exists fixed.